### PR TITLE
fix(auth): This fix is for axios interceptor and logout

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -136,3 +136,4 @@ dist
 dist
 
 .idea
+.vscode

--- a/src/constants/routes.js
+++ b/src/constants/routes.js
@@ -81,7 +81,7 @@ export const Approutes = {
 
 //export const backendLink = process.env.NODE_ENV !== "sam" ? 'http://109.237.25.252:4000/' : 'http://localhost:4000/';
 export const backendLink =
-	import.meta.env.VITE_CHECK_ENV === 'sam_devnm'
+	import.meta.env.VITE_CHECK_ENV === 'sam_dev'
 		? 'http://localhost:4000/'
 		: 'https://api.boonfu.site/';
 

--- a/src/pages/auth/Logout.jsx
+++ b/src/pages/auth/Logout.jsx
@@ -1,6 +1,6 @@
 import { useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
-import {ScrollToTop, getRefreshToken} from '../../utils';
+import { ScrollToTop, getRefreshToken } from '../../utils';
 import { backendLink } from '../../constants';
 import { api } from '../../utils/axios';
 import useAuth from '../../context/UserContext';
@@ -10,65 +10,61 @@ import { useNotify } from '../../hooks';
 import useMessageContext from '../../context/MessageContext';
 
 const Logout = () => {
-	const notify = useNotify();
-	const { logout } = useAuth();
-	const navigate = useNavigate();
-	const { disconnect_socket } = useMessageContext();
+  const notify = useNotify();
+  const { logout } = useAuth();
+  const navigate = useNavigate();
+  const { disconnect_socket } = useMessageContext();
 
-	useEffect(() => {
-		// notifyInf(
-		//   "You are been logout. Allow us clean up your space against Hackers."
-		// );
-		const logoutBackend = async () => {
-			await api
-				.get(`${backendLink}auth/logout`, {
-					headers: {
-						Authorization: `Bearer ${getRefreshToken()}`,
-						'Content-Type': 'application/json',
-						Accept: 'application/json',
-					},
-				})
-				.then(({ data }) => {
-					const { message } = data;
-					notify(message, 'success');
-					return;
-				})
-				.catch(({ response }) => {
-					const { message } = response.data;
-					if (message !== undefined) {
-						notify(message, 'error');
-					} else {
-						notify('Something went wrong.', 'error');
-					}
-				});
-			// remove the user details from localStorage
-			//clearLocalStorage();
-			logout();
-			disconnect_socket();
-			navigate('/', { replace: 'true' });
-		};
-		setTimeout(() => {
-			logoutBackend();
-		}, 4000);
+  const MESSAGE = 'Backend Logout finished and tokens destroyed';
+  useEffect(() => {
+    const logoutBackend = async () => {
+      await api
+        .post(
+          `${backendLink}auth/logout`,
+          {
+            refreshToken: getRefreshToken(),
+          },
+          {
+            headers: {
+              Authorization: `Bearer ${getRefreshToken()}`,
+              'Content-Type': 'application/json',
+              Accept: 'application/json',
+            },
+          }
+        )
+        .then(() => {
+          notify(MESSAGE, 'success');
+          return;
+        })
+        .catch(({ response }) => {
+          notify(MESSAGE, 'success');
+        });
+      // remove the user details from localStorage
+      //clearLocalStorage();
+      logout();
+      disconnect_socket();
+      navigate('/', { replace: 'true' });
+    };
+    setTimeout(() => {
+      logoutBackend();
+    }, 4000);
 
-		return;
-	}, []);
+    return;
+  }, []);
 
-	return (
-		<div className="my-16 lg:my-20">
-			<SpinnerSkeleton
-				heading={'Logout in Process...'}
-				body={
-					'Our Logout is done securely. We are cleaning up your space to keep you safe from Hackers. We hope to see you soon. Bye 🙋‍♂️'
-				}
-				type={'spin'}
-				color={'#2686CE'}
-				height={250}
-				width={250}
-			/>
-			<ScrollToTop />
-		</div>
-	);
+  return (
+    <div className='my-16 lg:my-20'>
+      <SpinnerSkeleton
+        heading={'Logout in Process...'}
+        body={'Our Logout is done securely. We are cleaning up your space to keep you safe from Hackers. We hope to see you soon. Bye 🙋‍♂️'}
+        type={'spin'}
+        color={'#2686CE'}
+        height={250}
+        width={250}
+      />
+      <ScrollToTop />
+    </div>
+  );
 };
 
 export default Logout;

--- a/src/utils/axios.js
+++ b/src/utils/axios.js
@@ -54,10 +54,6 @@ privateAxios.interceptors.response.use(
 				// return Promise.reject(error);
 			}
 		}
-		if(error.response.status === 401) {
-            setRedirectLink(window.location.pathname);
-            return window.location.assign(Approutes.auth.initial);
-        }
 		return Promise.reject(error);
 	}
 );

--- a/vite.config.js
+++ b/vite.config.js
@@ -7,6 +7,9 @@ dotenv.config() // load env vars from .env
 
 // https://vitejs.dev/config/
 export default defineConfig({
+	build: {
+		sourcemap: true,
+	},
 	plugins: [react()],
 	server: {
 		host: true,


### PR DESCRIPTION
There is a problem with fetching refresh token during axios interception of response, and also the backend changes to logout in implementing token accountability.

Backend now implement a way of saving token and validating token to avoid token poisoning. With the new poisoning, we can't have a bad actor extract user token to make request when the user is already logged out.

Also, implemented the interceptor for axios. To fetch access token when axios reponse with `401` status code.

Closes issue: https://github.com/afficode/backend/issues/57
Closes issue: https://github.com/afficode/frontend/issues/141

DCO 1.1 Signed-off-by Samuel Chika <samuelemyrs@gmail.com>