### PR TITLE
fix(disable_close_button): this PR disables close button

### DIFF
--- a/src/pages/Profile/Adverts/AdCard.jsx
+++ b/src/pages/Profile/Adverts/AdCard.jsx
@@ -115,6 +115,7 @@ const AdCard = ({ title, images, active, price, subscribe, views, adId, chats, p
 							size={'small'}
 							className={'text-primary rounded-lg shadow-none hover:shadow-md'}
 							onClick={() => closeAdvert()}
+                            disabled={active === '2'}
 						>
 							Close
 						</Button>


### PR DESCRIPTION
This PR introduces a close button to the Advert card. If an add is marked as close, the close button should be disabled.

contributes to: https://github.com/afficode/frontend/issues/149 
closes https://github.com/afficode/frontend/issues/166

DCO 1.1 Signed-off-by Samuel Chika <samuelemyrs@gmail.com>