### PR TITLE
fix(format_option_software): fix other option

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,5 @@
 {
 	"cSpell.words": ["Approutes", "Boonfu", "daisyui", "firstname", "flowbite", "Formik", "mytheme"],
-	"DockerRun.DisableDockerrc": true
+	"DockerRun.DisableDockerrc": true,
+	"postman.settings.dotenv-detection-notification-visibility": false
 }

--- a/src/pages/PostAd/CategoryForm.jsx
+++ b/src/pages/PostAd/CategoryForm.jsx
@@ -2367,7 +2367,7 @@ const CategoryForm = ({ categoryId, categoryName, initialValues }) => {
 			otherFormat && {
 				control: 'input',
 				label: 'Other Format',
-				name: 'format',
+				name: 'format_other',
 				type: 'text',
 				placeholder: 'Enter format',
 				required: true,
@@ -3848,7 +3848,7 @@ const CategoryForm = ({ categoryId, categoryName, initialValues }) => {
 		));
 
 	const notify = useNotify();
-	const { mutate } = useCreateAd();
+	const { mutate, isPending } = useCreateAd();
 	const navigate = useNavigate();
 
 	// payment window modal
@@ -4056,7 +4056,7 @@ const CategoryForm = ({ categoryId, categoryName, initialValues }) => {
 							<Button
 								onClick={() => setPaymentWindow(true)}
 								type="button"
-								loading={formik.isSubmitting}
+								loading={formik.isSubmitting || isPending}
 								variant="primary"
 								size="full"
 								// token < adToken ||
@@ -4069,7 +4069,7 @@ const CategoryForm = ({ categoryId, categoryName, initialValues }) => {
 							<Button
 								onClick={formik.handleSubmit}
 								type="button"
-								loading={formik.isSubmitting}
+								loading={formik.isSubmitting || isPending}
 								variant="primary"
 								size="full"
 								// token < adToken ||

--- a/src/pages/UpdateAd/CategoryForm.jsx
+++ b/src/pages/UpdateAd/CategoryForm.jsx
@@ -2378,7 +2378,7 @@ const CategoryForm = ({
 			otherFormat && {
 				control: 'input',
 				label: 'Other Format',
-				name: 'format',
+				name: 'format_other',
 				type: 'text',
 				placeholder: 'Enter format',
 				required: true,

--- a/src/pages/UpdateAd/index.jsx
+++ b/src/pages/UpdateAd/index.jsx
@@ -242,6 +242,7 @@ const PostAd = () => {
 			platform: ad?.platform,
 			type: ad?.type,
 			format: ad?.format,
+			format_other: ad?.format_other,
 			release_year: ad?.release_year,
 			game_genre: ad?.game_genre,
 			rating: ad?.rating,

--- a/src/utils/dataManipulations.js
+++ b/src/utils/dataManipulations.js
@@ -103,34 +103,43 @@ export const convertKeyToName = (ad) => {
 		'sim_type',
 		'exchange_possible',
 	];
-	var overviews = [];
-	if (ad === null || undefined) {
-		return [];
-	} else {
-		keys.forEach((key) => {
-			if (key in ad) {
-				if (key.includes('_')) {
-					const name = key
-						.split('_')
-						.map((val) => val[0].toUpperCase() + val.substring(1))
-						.join(' ');
-					overviews.push({
-						name,
-						param: key,
-						value: key === 'date_available' ? format(new Date(ad[key]), 'PP') : ad[key],
-					});
-				} else {
-					// it does not contain _
-					const name = key[0].toUpperCase() + key.substring(1);
-					overviews.push({
-						name,
-						param: key,
-						value: ad[key],
-					});
-				}
-			}
-		});
-	}
+
+	if (!ad) return [];
+
+	const overviews = [];
+
+	keys.forEach((key) => {
+		if (!(key in ad)) return;
+
+		const displayName = key
+			.split('_')
+			.map((val) => val[0].toUpperCase() + val.slice(1))
+			.join(' ');
+
+		let value = ad[key];
+
+		// Handle "other" case
+		if (value === 'other') {
+			const otherKey = `${key}_other`;
+			const otherValue = ad[otherKey];
+
+			// Skip if no corresponding *_other field or it's empty
+			if (!otherValue) return;
+
+			value = otherValue;
+		}
+
+		// Skip if value is null, undefined, or empty string
+		if (value == null || value === '') return;
+
+		// Format date
+		if (key === 'date_available') {
+			value = format(new Date(value), 'PP');
+		}
+
+		overviews.push({ name: displayName, param: key, value });
+	});
+
 	return overviews;
 };
 
@@ -203,6 +212,10 @@ export const formatCardNumber = (cardNumber, spacing = 4) => {
 };
 
 export const getInitials = (name) => {
-	const initials = name.split(' ').map((word) => word[0]).join('').toUpperCase();
+	const initials = name
+		.split(' ')
+		.map((word) => word[0])
+		.join('')
+		.toUpperCase();
 	return initials;
 };


### PR DESCRIPTION
This commit addresses the other option in format field Now if a user selects other in the format field
format will be sent as 'other'
then another field will be created 'format_other' which will contain the new value Also format_other value will be correctly displayed in format Its also accounted for during edit

This closes issue: #133

DCO 1.1 Signed-off-by Godstime Agholor agholorgodstime18@gmail.com