### PR TITLE
fix(user_ad_status): displaying correct ad status to user

### DIFF
--- a/src/pages/Products/View/ContactAdmin.jsx
+++ b/src/pages/Products/View/ContactAdmin.jsx
@@ -37,11 +37,11 @@ export default function ContactAdmin({ ads_id, images }) {
 			const timelineData =
 				data?.data?.remark?.length > 0
 					? data?.data?.remark?.map((el) => ({
-							date: el?.date,
-							title: el?.name,
-							body: el?.text,
-							user: el?.user_id,
-					  }))
+						date: el?.date,
+						title: el?.name,
+						body: el?.text,
+						user: el?.user_id,
+					}))
 					: [];
 			setRemark(() => timelineData);
 		};
@@ -53,7 +53,7 @@ export default function ContactAdmin({ ads_id, images }) {
 	return (
 		<>
 			<div className="mb-4 mt-2 text-red-700 dark:text-red-800">
-				<p className="w-full p-2 bg-white my-4 pt-4">
+				<p className="w-full p-2 pt-4">
 					<Timeline data={remark} />
 				</p>
 				<ul className="list-disc ml-4">

--- a/src/pages/Products/View/MakePayment.jsx
+++ b/src/pages/Products/View/MakePayment.jsx
@@ -1,8 +1,12 @@
-import React from 'react';
+import { useNavigate } from 'react-router-dom';
 import { FaMoneyBillTrendUp } from 'react-icons/fa6';
 import { makeAdPayment, deleteAd } from '../../../hooks';
 import { useNotify } from '../../../hooks';
+import { useQueryClient } from 'react-query';
+import { Approutes } from '../../../constants';
 const MakePayment = ({ ad_id }) => {
+    const queryClient = useQueryClient();
+    const navigate = useNavigate();
     const notify = useNotify();
     const { mutate, isLoading } = makeAdPayment();
     const { mutate: adDelete, isLoading: deleteAdLoading } = deleteAd();
@@ -10,6 +14,7 @@ const MakePayment = ({ ad_id }) => {
         mutate(id, {
             onSuccess: (data) => {
                 notify(data?.message, 'success');
+                queryClient.invalidateQueries({ queryKey: ['fetch-product', ad_id] });
             },
             onError: (error) => {
                 notify('Error paying for this AD', 'error');
@@ -20,8 +25,10 @@ const MakePayment = ({ ad_id }) => {
         adDelete(id, {
             onSuccess: (data) => {
                 notify(data?.message, 'success');
+                navigate(Approutes.dashboard.initial);
+
             },
-            onError: (error) => {
+            onError: () => {
                 notify('Error deleting this AD', 'error');
             },
         });

--- a/src/pages/Products/View/index.jsx
+++ b/src/pages/Products/View/index.jsx
@@ -53,7 +53,7 @@ const index = () => {
         <ViewProduct />
     ) : user?.id === result?.data?.user_id ? (
         <section className='w-full px-4 py-2 lg:py-4 lg:px-8'>
-            {result?.data?.paid === 0 && user.id === result?.data.owner ? (
+            {(result?.data?.paid === 0 && user.id === result?.data.owner) ? (
                 <div className='w-[90%] lg:w-[70%] my-3 mx-auto'>
                     <Alert
                         additionalContent={
@@ -68,6 +68,29 @@ const index = () => {
                         </span>{' '}
                     </Alert>
                 </div>
+            ) : result?.data?.paid === 1 && result?.data?.available === 0 ? (
+                <div className='w-[90%] lg:w-[70%] my-3 mx-auto'>
+                    <Alert
+                        // additionalContent={<ContactAdmin />}
+                        color='info'
+                    >
+                        <h5 className='font-medium text-red-600'>
+                            Ad Post successfully:{' '}
+                        </h5>{' '}
+                        <div className=''>
+                            {' '}
+                            This Ad is been processed ATM. Processing time is less than 24 hours. If this takes more than 24 hours please reach out to Admin with the contact form with the below details.
+                            <ul className='list-disc list-inside font-bold '>
+                                <li className='text-sm'>Ad Title</li>
+                                <li className='text-sm'>Your email address</li>
+                                <li className='text-sm'>Date Posted</li>
+                            </ul>
+                            <div className="w-full font-bold my-2 bg-secondary text-white p-2">
+                                Please ensure the Ad title matches exactly what you have in your Ad. This will facilitate the response to your request.
+                            </div>
+                        </div>
+                    </Alert>
+                </div>
             ) : (
                 result?.data.active === '0' &&
                 user.id === result?.data.owner && (
@@ -77,13 +100,15 @@ const index = () => {
                             color='warning'
                             icon={HiInformationCircle}
                         >
-                            <span className='font-medium text-red-600'>
-                                Ad Blocked:{' '}
-                            </span>{' '}
-                            <span className='underline'>
-                                {' '}
-                                Change a few things up and try submitting again.
-                            </span>
+                            <div>
+                                <span className='font-medium text-red-600'>
+                                    Ad Blocked:{' '}<span className='underline'>
+                                        {' '}
+                                        Change a few things up and try submitting again.
+                                    </span>
+                                </span>{' '}
+
+                            </div>
                         </Alert>
                     </div>
                 )
@@ -224,23 +249,6 @@ const index = () => {
         </section>
     ) : (
         <section className='w-full p-2 lg:p-4'>
-            {result?.data.active === '0' && user.id === result?.data.owner && (
-                <div className='w-[90%] lg:w-[70%] my-3 mx-auto'>
-                    <Alert
-                        additionalContent={<ContactAdmin />}
-                        color='warning'
-                        icon={HiInformationCircle}
-                    >
-                        <span className='font-medium text-red-600'>
-                            Ad Blocked:{' '}
-                        </span>{' '}
-                        <span className='underline'>
-                            {' '}
-                            Change a few things up and try submitting again.
-                        </span>
-                    </Alert>
-                </div>
-            )}
             <header className='w-full'>
                 <Breadcrumb
                     items={items}

--- a/src/pages/Profile/Adverts/AdCard.jsx
+++ b/src/pages/Profile/Adverts/AdCard.jsx
@@ -24,7 +24,9 @@ const AdCard = ({ title, images, active, price, subscribe, views, adId, chats, p
 		mutate(formData, {
 			onSuccess: (data) => {
 				notify('Advert closed successfully', 'success');
-				queryClient.invalidateQueries({ queryKey: ['getUserAds'] });
+				setTimeout(() => {
+					queryClient.invalidateQueries({ queryKey: ['getUserAds'] });
+				}, 3000);
 			},
 			onError: () => {
 				notify('Error closing Ad. If this error persist, please contact Admin with the contact us form.', 'error');
@@ -36,7 +38,9 @@ const AdCard = ({ title, images, active, price, subscribe, views, adId, chats, p
 		makePaymentMutate(adId, {
 			onSuccess: (data) => {
 				notify(data?.message || 'Payment Queued. You will be notified by email when payment is done.', 'success');
-				queryClient.invalidateQueries({ queryKey: ['getUserAds'] });
+				setTimeout(() => {
+					queryClient.invalidateQueries({ queryKey: ['getUserAds'] });
+				}, 3000);
 			},
 			onError: () => {
 				notify('Error making payment. If this error persist, please contact Admin with the contact us form.', 'error');
@@ -64,7 +68,7 @@ const AdCard = ({ title, images, active, price, subscribe, views, adId, chats, p
 					</span>
 				)}
 				{(active === '0' && available === 0) && (
-					<div className="absolute top-4 right-4 text-white font-semibold bg-secondary py-1 px-2 rounded-xl text-center border-4 border-white max-sm:text-sm">
+					<div className={`absolute top-4 right-4 text-white font-semibold ${paid === 0 ? 'bg-orange-500' : 'bg-secondary'} py-1 px-2 rounded-xl text-center border-4 border-white max-sm:text-sm`}>
 						{paid === 0 ? <span className='flex items-center justify-center cursor-pointer' onClick={() => makePayment()}>Payment Required &emsp; <FaUnlock /></span> : <span>Processing</span>}
 					</div>
 				)}

--- a/src/pages/Profile/Adverts/index.jsx
+++ b/src/pages/Profile/Adverts/index.jsx
@@ -14,7 +14,6 @@ const Adverts = () => {
 
 	const adsData = ads?.active_ads.sort((a, b) => b.id - a.id);
 
-	console.log(ads);
 	return (
 		<div className="max-w-[1224px] mx-auto px-4 my-10">
 			<div className="px-2 py-6 mb-12 space-y-8 border lg:px-8 border-black/30 rounded-3xl">
@@ -35,7 +34,7 @@ const Adverts = () => {
 							: 'text-green-500 lg:py-2 lg:px-6 py-1 px-4'
 							} cursor-pointer max-sm:text-sm`}
 					>
-						Active <span>[{ads?.active_ads?.length || 0}]</span>
+						Active <span>[{ads?.active_ads.length || 0}]</span>
 					</div>
 					<div
 						onClick={() => setFilteredAd('processing')}
@@ -44,7 +43,7 @@ const Adverts = () => {
 							: 'text-secondary lg:py-2 lg:px-6 py-1 px-4'
 							} cursor-pointer max-sm:text-sm`}
 					>
-						Processing <span>[{ads?.processing_ads?.length || 0}]</span>
+						Processing <span>[{ads?.processing_ads.filter(ad => ad.active === '0' && ad.available === 0 && ad.paid === 1).length || 0}]</span>
 					</div>
 					<div
 						onClick={() => setFilteredAd('blocked')}
@@ -53,17 +52,17 @@ const Adverts = () => {
 							: 'text-[#D60949] lg:py-2 lg:px-6 py-1 px-4'
 							} cursor-pointer max-sm:text-sm`}
 					>
-						Blocked <span>[{ads?.blocked_ads?.length || 0}]</span>
+						Blocked <span>[{ads?.blocked_ads.length || 0}]</span>
 					</div>
-					{/* <div
-						onClick={() => setFilteredAd('draft')}
-						className={`${filteredAd === 'draft'
+					<div
+						onClick={() => setFilteredAd('payment_required')}
+						className={`${filteredAd === 'payment_required'
 							? 'bg-primary text-white lg:py-2 lg:px-6 py-1 px-4'
-							: ' lg:py-2 lg:px-6 py-1 px-4'
+							: ' lg:py-2 lg:px-6 py-1 px-4 text-orange-500'
 							} cursor-pointer max-sm:text-sm`}
 					>
-						Draft <span>[2]</span>
-					</div> */}
+						Payment Required <span>[{ads?.processing_ads.filter(ad => ad.active === '0' && ad.available === 0 && ad.paid === 0).length || 0}]</span>
+					</div>
 					<div
 						onClick={() => setFilteredAd('sold')}
 						className={`${filteredAd === 'sold'
@@ -71,7 +70,7 @@ const Adverts = () => {
 							: 'text-black/50 lg:py-2 lg:px-6 py-1 px-4'
 							} cursor-pointer max-sm:text-sm`}
 					>
-						Closed <span>[{ads?.sold_ads?.length || 0}]</span>
+						Closed <span>[{ads?.sold_ads.length || 0}]</span>
 					</div>
 				</div>
 				<div className="max-w-[400px] mx-auto">
@@ -86,81 +85,96 @@ const Adverts = () => {
 				<LoadingScreen />
 			) : (
 				<div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-3 place-items-center">
-					{(ads && ads?.total_ads > 0) ? (filteredAd === 'active' ? adsData?.map((ad) => (
+					{(ads && ads.total_ads > 0) ? (filteredAd === 'active' ? adsData.map((ad) => (
 						<AdCard
-							key={ad?.id}
-							title={ad?.title}
-							images={ad?.images}
-							active={ad?.active}
-							price={ad?.price}
+							key={ad.id}
+							title={ad.title}
+							images={ad.images}
+							active={ad.active}
+							price={ad.price}
 							views={ad.views}
-							subscribe={ad?.subscribe}
-							adId={ad?.id}
-							chats={ad?.chats}
-							paid={ad?.paid}
-							available={ad?.available}
+							subscribe={ad.subscribe}
+							adId={ad.id}
+							chats={ad.chats}
+							paid={ad.paid}
+							available={ad.available}
 						/>
-					)) : filteredAd === 'processing' ? ads?.processing_ads?.map((ad) => (
+					)) : filteredAd === 'processing' ? ads.processing_ads.filter(ad => ad.active === '0' && ad.available === 0 && ad.paid === 1).sort((a, b) => b.id - a.id).map((ad) => (
 						<AdCard
-							key={ad?.id}
-							title={ad?.title}
-							images={ad?.images}
-							active={ad?.active}
-							price={ad?.price}
+							key={ad.id}
+							title={ad.title}
+							images={ad.images}
+							active={ad.active}
+							price={ad.price}
 							views={ad.views}
-							subscribe={ad?.subscribe}
-							adId={ad?.id}
-							chats={ad?.chats}
-							paid={ad?.paid}
-							available={ad?.available}
+							subscribe={ad.subscribe}
+							adId={ad.id}
+							chats={ad.chats}
+							paid={ad.paid}
+							available={ad.available}
 
 						/>
-					)) : filteredAd === 'blocked' ? ads?.blocked_ads?.map((ad) => (
+					)) : filteredAd === 'blocked' ? ads.blocked_ads.sort((a, b) => b.id - a.id).map((ad) => (
 						<AdCard
-							key={ad?.id}
-							title={ad?.title}
-							images={ad?.images}
-							active={ad?.active}
-							price={ad?.price}
+							key={ad.id}
+							title={ad.title}
+							images={ad.images}
+							active={ad.active}
+							price={ad.price}
 							views={ad.views}
-							subscribe={ad?.subscribe}
-							adId={ad?.id}
-							chats={ad?.chats}
-							paid={ad?.paid}
-							available={ad?.available}
+							subscribe={ad.subscribe}
+							adId={ad.id}
+							chats={ad.chats}
+							paid={ad.paid}
+							available={ad.available}
 
 						/>
-					)) : filteredAd === 'sold' ? ads?.sold_ads?.map((ad) => (
+					)) : filteredAd === 'payment_required' ? ads.processing_ads.filter(ad => ad.active === '0' && ad.available === 0 && ad.paid === 0).sort((a, b) => b.id - a.id).map((ad) => (
 						<AdCard
-							key={ad?.id}
-							title={ad?.title}
-							images={ad?.images}
-							active={ad?.active}
-							price={ad?.price}
+							key={ad.id}
+							title={ad.title}
+							images={ad.images}
+							active={ad.active}
+							price={ad.price}
 							views={ad.views}
-							subscribe={ad?.subscribe}
-							adId={ad?.id}
-							chats={ad?.chats}
-							paid={ad?.paid}
-							available={ad?.available}
+							subscribe={ad.subscribe}
+							adId={ad.id}
+							chats={ad.chats}
+							paid={ad.paid}
+							available={ad.available}
+
 						/>
-					)) : [...(ads?.sold_ads ?? []),
-					...(ads?.active_ads ?? []),
-					...(ads?.blocked_ads ?? []),
-					...(ads?.processing_ads ?? [])
+					)) : filteredAd === 'sold' ? ads.sold_ads.sort((a, b) => b.id - a.id).map((ad) => (
+						<AdCard
+							key={ad.id}
+							title={ad.title}
+							images={ad.images}
+							active={ad.active}
+							price={ad.price}
+							views={ad.views}
+							subscribe={ad.subscribe}
+							adId={ad.id}
+							chats={ad.chats}
+							paid={ad.paid}
+							available={ad.available}
+						/>
+					)) : [...(ads.sold_ads ?? []),
+					...(ads.active_ads ?? []),
+					...(ads.blocked_ads ?? []),
+					...(ads.processing_ads ?? [])
 					].sort((a, b) => b.id - a.id).map((ad) => (
 						<AdCard
-							key={ad?.id}
-							title={ad?.title}
-							images={ad?.images}
-							active={ad?.active}
-							price={ad?.price}
+							key={ad.id}
+							title={ad.title}
+							images={ad.images}
+							active={ad.active}
+							price={ad.price}
 							views={ad.views}
-							subscribe={ad?.subscribe}
-							adId={ad?.id}
-							chats={ad?.chats}
-							paid={ad?.paid}
-							available={ad?.available}
+							subscribe={ad.subscribe}
+							adId={ad.id}
+							chats={ad.chats}
+							paid={ad.paid}
+							available={ad.available}
 						/>
 					))) : (
 						<div>


### PR DESCRIPTION
This PR address the issue where customer sees a blocked status on an ad instead of the necessary status of :
- payment required
- blocked
- processing

The previous information was misleading.

This implementation introduced changes to the Advert page as below:
- Categorizing Ads into different category of availability with count.
- Filter user adverts with regards to ad status
- display right alert to user when viewing their own ad.
- User can make payment directly when viewing their own Ad and also when viewing ad from their advert page with badge: payment required.

Closes: https://github.com/afficode/frontend/issues/167

DCO 1.1 Signed-off-by Samuel Chika <samuelemyrs@gmail.com>