### PR TITLE
fix(update user): update phone number in browser

### DIFF
--- a/src/pages/Dashboard/Profile/VerifyPhoneNumber.jsx
+++ b/src/pages/Dashboard/Profile/VerifyPhoneNumber.jsx
@@ -3,6 +3,7 @@ import { TbPhoneCheck } from "react-icons/tb";
 import { useNotify, useVerifyPhoneNumber } from "../../../hooks";
 import { Button, Modal } from "flowbite-react";
 import { BsAlarmFill } from "react-icons/bs";
+import { updateUserPhoneVerified } from "../../../utils";
 
 // call back end api and verify otp is sent then activate modal
 const VerifyPhoneNumber = ({ phoneDetails }) => {
@@ -130,6 +131,7 @@ const ConfirmPhoneNumber = ({ phoneDetails, sendOtp, setOpenModal }) => {
 
         mutate(data, {
             onSuccess: (data) => {
+                updateUserPhoneVerified(1);
                 notify(data?.message, 'success');
                 setOpenModal(false);
             },

--- a/src/pages/Dashboard/Profile/index.jsx
+++ b/src/pages/Dashboard/Profile/index.jsx
@@ -33,7 +33,8 @@ const Profile = () => {
 	const { mutate, isLoading: isUpdating } = userUpdate('dashboard/update_user');
 	const notify = useNotify();
 
-	const phoneDetails = user?.phone.filter((num) => num.isDefault === '1')[0]
+	const index = user?.phone.findIndex((num) => num.isDefault === '1');
+	const phoneDetails = user?.phone[index];
 
 	const initialValues = {
 		phone: phoneDetails.number || 1000000000,
@@ -59,14 +60,23 @@ const Profile = () => {
 			delete values.established;
 			delete values.name;
 
-			if (values.phone.toString().substring(0, 1) !== '0') {
+			const payload = Object.assign({}, values);
+
+			if (payload.phone.toString().substring(0, 1) !== '0') {
+				payload.phone = '0' + payload.phone.toString();
 				values.phone = '0' + values.phone.toString();
 			}
+
+			if (payload.phone === phoneDetails.number) {
+				delete payload.phone;
+			}
+
 			const formData = new FormData();
-			Object.entries(values).forEach(([key, value]) => {
+			Object.entries(payload).forEach(([key, value]) => {
 				formData.append(key, value);
 			});
-			await mutate(formData, {
+
+			mutate(formData, {
 				onSuccess: async (data) => {
 					updateUserInfo(data?.user);
 					notify(data?.message, 'success');

--- a/src/utils/dataManipulations.js
+++ b/src/utils/dataManipulations.js
@@ -1,4 +1,5 @@
 import { format } from 'date-fns';
+import { getUserFromLocalStorage, setUser } from './localstorage';
 export const manipulateCategory = (category) => {
 	const categories = Object.groupBy(category, ({ category_id }) => category_id);
 
@@ -143,8 +144,7 @@ export const convertKeyToName = (ad) => {
 	return overviews;
 };
 
-export const arrayRange = (start, stop, step) =>
-	Array.from({ length: (stop - start) / step + 1 }, (value, index) => start + index * step);
+export const arrayRange = (start, stop, step) => Array.from({ length: (stop - start) / step + 1 }, (value, index) => start + index * step);
 
 export const getStateLGA = (lga, state_id) => {
 	const state_lga = lga.filter((val) => val.state_id === state_id);
@@ -200,9 +200,7 @@ export const manipulatePrice = (price, category_id) => {
 export const manipulateFilterForm = (values, category_id) => {
 	// remove all the empty of null fields
 	var filteredValue = removeNullObjectsValues(values);
-	filteredValue = filteredValue?.price
-		? { ...filteredValue, price: manipulatePrice(filteredValue.price, category_id) }
-		: filteredValue;
+	filteredValue = filteredValue?.price ? { ...filteredValue, price: manipulatePrice(filteredValue.price, category_id) } : filteredValue;
 	return filteredValue;
 };
 
@@ -218,4 +216,33 @@ export const getInitials = (name) => {
 		.join('')
 		.toUpperCase();
 	return initials;
+};
+
+export const setNestedValueForUser = (path, value) => {
+	const keys = path.split('.');
+	const user = getUserFromLocalStorage();
+	let ref = user;
+
+	while (keys.length > 1) {
+		const key = keys.shift();
+		ref = ref[key] = ref[key] || {};
+	}
+
+	ref[keys[0]] = value;
+	setUser(user);
+};
+
+export const updateUserPhoneVerified = (value) => {
+	const user = getUserFromLocalStorage();
+	if (!Array.isArray(user?.phone)) {
+		return;
+	}
+
+	const index = user.phone.findIndex((num) => num.isDefault === '1');
+	if (index === -1) {
+		return;
+	}
+
+	user.phone[index].isVerified = value;
+	setUser(user);
 };


### PR DESCRIPTION
This PR addresses the issue of verify phone number.
Previously, users after verifying phone number, have to re-auth before seeing effect, there by showing a UI of success and still having verify phone button.

This PR updates the user phone number in the user payload when a successful verification is done.

Users don't need to re-auth.

Also, the phone number payload will not make it to the backend if it did not change.  If its changed, the user payload is updated and the user have to re-verify the number.

Closes issue: https://github.com/afficode/frontend/issues/181

DCO 1.1 Signed-off-by Samuel Chika <samuelemyrs@gmail.com>