### PR TITLE
fix(notification_redirect): inspection log redirect based on view

### DIFF
--- a/src/pages/Profile/Notifications/NotificationCard.jsx
+++ b/src/pages/Profile/Notifications/NotificationCard.jsx
@@ -3,18 +3,22 @@ import { useNavigate } from 'react-router-dom';
 import { format } from 'date-fns';
 import { Approutes } from '../../../constants';
 import { useNotifications } from '../../../context/Notification';
+import useAuth from '../../../context/UserContext';
 
-const NotificationCard = ({ feature, body, time, id, adId, isRead }) => {
+const NotificationCard = ({ feature, body, time, id, adId, isRead, metadata, user_id }) => {
 	const navigate = useNavigate();
 	const { markAsRead } = useNotifications();
+	const { user } = useAuth();
 
 	return (
 		<div
-			role="button"
+			role='button'
 			onClick={() => {
 				markAsRead(id);
 				navigate(
-					feature.includes('inspection_log')
+					feature.includes('inspection_log') && metadata && metadata?.ad_owner === user.id
+						? Approutes.product.initial + '/' + adId
+						: feature.includes('inspection_log')
 						? Approutes.grab.inspectionLog
 						: feature.includes('escrow')
 						? Approutes.profile.transactions
@@ -25,13 +29,11 @@ const NotificationCard = ({ feature, body, time, id, adId, isRead }) => {
 						: null
 				);
 			}}
-			className={`${
-				isRead === 1 ? 'bg-white' : 'bg-primary/20'
-			} w-full h-full p-2 sm:p-4 flex items-start rounded-md gap-3 border-t-2 border-t-gray-200 mb-2`}
+			className={`${isRead === 1 ? 'bg-white' : 'bg-primary/20'} w-full h-full p-2 sm:p-4 flex items-start rounded-md gap-3 border-t-2 border-t-gray-200 mb-2`}
 		>
 			{/* details  */}
-			<div className="flex flex-col gap-2 justify-between flex-1">
-				<div className="flex items-center max-[420px]:items-stretch max-[420px]:flex-col-reverse justify-between gap-4 max-[420px]:gap-2">
+			<div className='flex flex-col gap-2 justify-between flex-1'>
+				<div className='flex items-center max-[420px]:items-stretch max-[420px]:flex-col-reverse justify-between gap-4 max-[420px]:gap-2'>
 					<span
 						className={`px-2 py-1 capitalize ${
 							feature.includes('escrow_refund_resolved')
@@ -48,18 +50,18 @@ const NotificationCard = ({ feature, body, time, id, adId, isRead }) => {
 						{feature.split('_').join(' ')}
 					</span>
 
-					<div className="sm:hidden max-[420px]:justify-end flex items-center justify-start gap-1 text-xs text-gray-400">
-						<IoMdTime className="text-gray-400" /> {format(new Date(time), "d MMM yyyy 'at' h:mm a")}
+					<div className='sm:hidden max-[420px]:justify-end flex items-center justify-start gap-1 text-xs text-gray-400'>
+						<IoMdTime className='text-gray-400' /> {format(new Date(time), "d MMM yyyy 'at' h:mm a")}
 					</div>
 				</div>
 
 				<div>
-					<p className="text-sm ellipsis-text w-full text-gray-500">{body}</p>
+					<p className='text-sm ellipsis-text w-full text-gray-500'>{body}</p>
 				</div>
 			</div>
 
-			<div className="max-sm:hidden flex items-center justify-start gap-1 text-xs text-gray-400">
-				<IoMdTime className="text-gray-400" /> {format(new Date(time), "d MMM yyyy 'at' h:mm a")}
+			<div className='max-sm:hidden flex items-center justify-start gap-1 text-xs text-gray-400'>
+				<IoMdTime className='text-gray-400' /> {format(new Date(time), "d MMM yyyy 'at' h:mm a")}
 			</div>
 		</div>
 	);

--- a/src/pages/Profile/Notifications/index.jsx
+++ b/src/pages/Profile/Notifications/index.jsx
@@ -27,6 +27,7 @@ const Notifications = () => {
 						id={item.notification_id}
 						isRead={item.is_read}
 						adId={item.metadata?.ad_id}
+						metadata={item?.metadata}
 					/>
 				))}
 			</div>


### PR DESCRIPTION
This PR introduce to the notification redirect. If the person viewing the notification is the AD Owner, we redirect the user to their AD to see the inspection log from the AD page. If its the person interested, then the notification redirects them to the inspection log page.

DCO Signed Off: Samuel Ezeja <samuelemyrs@gmail.com>