### PR TITLE
feat

### DIFF
--- a/server.js
+++ b/server.js
@@ -14,6 +14,7 @@ const __dirname = path.dirname(__filename);
 const app = express();
 
 app.disable('x-powered-by');
+app.set('trust proxy', 1);
 
 const PORT = parseInt(process.env.PORT || '3000');
 


### PR DESCRIPTION
Express server is complaining about not setting `trust-proxy` since our coolify deployment is seating behind a proxy. We set `trust proxy` to `1`

DCO Signed Off: Samuel Chika <samuelemyrs@gmail.com>